### PR TITLE
Make it possible to keep null values in JSON after serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository contains only PHP files to support Composer installation. This r
 
 AdditionalFeatures:
 * Keep default values in generated JSON.
-By default protobuf compiler strips all default values. In sime cases it can be needed to keep them. It can be triggered by code below:
+By default protobuf compiler strips all default values. In some cases it can be needed to keep them. It can be triggered by code below:
 ```` 
 GPBWire::setKeepDefaultValues(true);
 ````

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # protobuf-php
 This repository contains only PHP files to support Composer installation. This repository is a mirror of [protobuf](https://github.com/protocolbuffers/protobuf). Any support requests, bug reports, or development contributions should be directed to that project. To install protobuf for PHP, please see https://github.com/protocolbuffers/protobuf/tree/master/php
+
+AdditionalFeatures:
+* Keep default values in generated JSON.
+By default protobuf compiler strips all default values. In sime cases it can be needed to keep them. It can be triggered by code below:
+```` 
+GPBWire::setKeepDefaultValues(true);
+````

--- a/src/Google/Protobuf/Internal/GPBWire.php
+++ b/src/Google/Protobuf/Internal/GPBWire.php
@@ -48,6 +48,16 @@ class GPBWire
     const NORMAL_FORMAT = 1;
     const PACKED_FORMAT = 2;
 
+    private static $keepDefaultValues = false;
+
+    public static function setKeepDefaultValues($keepDefaultValues) {
+        self::$keepDefaultValues = (bool) $keepDefaultValues;
+    }
+
+    public static function getKeepDefaultValues() {
+        return self::$keepDefaultValues;
+    }
+
     public static function getTagFieldNumber($tag)
     {
         return ($tag >> self::TAG_TYPE_BITS) &

--- a/src/Google/Protobuf/Internal/Message.php
+++ b/src/Google/Protobuf/Internal/Message.php
@@ -62,7 +62,6 @@ class Message
      */
     private $desc;
     private $unknown = "";
-    private static $keepDefaultValues = false;
 
     /**
      * @ignore
@@ -84,10 +83,6 @@ class Message
                 );
             }
         }
-    }
-
-    public static function setKeepDefaultValues($keepDefaultValues) {
-        self::$keepDefaultValues = (bool) $keepDefaultValues;
     }
 
     /**
@@ -1510,7 +1505,7 @@ class Message
             return $this->$oneof_name->getNumber() === $field->getNumber();
         }
 
-        if (static::$keepDefaultValues) {
+        if (GPBWire::getKeepDefaultValues()) {
             return true;
         }
 
@@ -1780,7 +1775,7 @@ class Message
             $getter = $field->getGetter();
             $values = $this->$getter();
             $count = count($values);
-            if (static::$keepDefaultValues || $count !== 0) {
+            if (GPBWire::getKeepDefaultValues() || $count !== 0) {
                 if (!GPBUtil::hasSpecialJsonMapping($this)) {
                     $size += 3;                              // size for "\"\":".
                     $size += strlen($field->getJsonName());  // size for field name
@@ -1816,7 +1811,7 @@ class Message
             $getter = $field->getGetter();
             $values = $this->$getter();
             $count = count($values);
-            if (static::$keepDefaultValues || $count !== 0) {
+            if (GPBWire::getKeepDefaultValues() || $count !== 0) {
                 if (!GPBUtil::hasSpecialJsonMapping($this)) {
                     $size += 3;                              // size for "\"\":".
                     $size += strlen($field->getJsonName());  // size for field name

--- a/src/Google/Protobuf/Internal/Message.php
+++ b/src/Google/Protobuf/Internal/Message.php
@@ -1504,13 +1504,14 @@ class Message
             $oneof_name = $oneof->getName();
             return $this->$oneof_name->getNumber() === $field->getNumber();
         }
-
-        if (GPBWire::getKeepDefaultValues()) {
-            return true;
-        }
-
+        
         $getter = $field->getGetter();
         $values = $this->$getter();
+
+        if (GPBWire::getKeepDefaultValues() && $values !== null) {
+            return true;
+        }
+       
         if ($field->isMap()) {
             return count($values) !== 0;
         } elseif ($field->isRepeated()) {


### PR DESCRIPTION
We use Protobuf to define API endpoints and spotted surprising behavior - items with default values are absent in the serialized JSON. It is uncommon for PHP REST APIs to have parameters disappearing from response when returned value is default one. This PR solves this problem without braking default behavior.

I would like to hear your feedback on proposed solution. Thanks.