### PR TITLE
Allow to keep default values in serialized JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # protobuf-php
 This repository contains only PHP files to support Composer installation. This repository is a mirror of [protobuf](https://github.com/protocolbuffers/protobuf). Any support requests, bug reports, or development contributions should be directed to that project. To install protobuf for PHP, please see https://github.com/protocolbuffers/protobuf/tree/master/php
+
+Features:
+* Keep default values in generated JSON.
+By default protobuf compiler strips all default values. In some cases it can be needed to keep them. It can be triggered by code below:
+```` 
+GPBWire::setKeepDefaultValues(true);
+````

--- a/src/Google/Protobuf/Internal/GPBWire.php
+++ b/src/Google/Protobuf/Internal/GPBWire.php
@@ -48,6 +48,16 @@ class GPBWire
     const NORMAL_FORMAT = 1;
     const PACKED_FORMAT = 2;
 
+    private static $keepDefaultValues = false;
+
+    public static function setKeepDefaultValues($keepDefaultValues) {
+        self::$keepDefaultValues = (bool) $keepDefaultValues;
+    }
+
+    public static function getKeepDefaultValues() {
+        return self::$keepDefaultValues;
+    }
+
     public static function getTagFieldNumber($tag)
     {
         return ($tag >> self::TAG_TYPE_BITS) &


### PR DESCRIPTION
We use Protobuf to define API endpoints and spotted surprising behavior - items with default values are absent in the serialized JSON. It is uncommon for PHP REST APIs to have parameters disappearing from response when returned value is default one. This PR solves this problem without braking default behavior.

I would like to hear your feedback on proposed solution. Thanks.