### PR TITLE
feat: emit default value

### DIFF
--- a/src/Google/Protobuf/Internal/Message.php
+++ b/src/Google/Protobuf/Internal/Message.php
@@ -1587,7 +1587,9 @@ class Message
         } elseif ($field->isRepeated()) {
             return count($values) !== 0;
         } else {
-            return $values !== $this->defaultValue($field);
+            // we want to emit default value
+            // return $values !== $this->defaultValue($field);
+            return false;
         }
     }
 


### PR DESCRIPTION
currently we omit the default value, and we want to show that instead of hiding it from the response